### PR TITLE
Accept array for "allow" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Feel free to [open issues on Github](http://github.com/apostrophecms/sluggo/issu
 
 ## Changelog
 
+### Unreleased
+- Accepts an array of exceptions in the `allow` options property while still accepting a string.
+
 ### 0.3.1 - 2021-04-23
 - Accepts the empty string as a legitimate value for `def`, as was always intended, rather than forcing `none` in that situation. If `def` is not set at all `none` is still the fallback default.
 

--- a/sluggo.js
+++ b/sluggo.js
@@ -33,7 +33,7 @@ var sluggo = function(s, options) {
   for (i = 0; (i < s.length); i++) {
     var code = s.charCodeAt(i);
     bad = false;
-    if ((options.allow !== undefined) && (options.allow === s.charAt(i))) {
+    if ((options.allow !== undefined) && (options.allow.includes(s.charAt(i)))) {
       // Make an exception
     } else {
       // efficient binary search for a disallow character code

--- a/test/test.js
+++ b/test/test.js
@@ -25,7 +25,7 @@ describe('sluggo', function() {
     var s = sluggo('/', { allow: '/' });
     assert.strictEqual(s, '/');
   });
-  it('Fallback default is none', function() {
+  it('fallback default is none', function() {
     var s = sluggo('@#(*&@', {});
     assert.strictEqual(s, 'none');
     var s = sluggo('', {});
@@ -33,7 +33,7 @@ describe('sluggo', function() {
     var s = sluggo('test', {});
     assert.strictEqual(s, 'test');
   });
-  it('Empty string can be passed as default', function() {
+  it('empty string can be passed as default', function() {
     var s = sluggo('@#(*&@', { def: '' });
     assert.strictEqual(s, '');
     var s = sluggo('', { def: '' });
@@ -41,4 +41,8 @@ describe('sluggo', function() {
     var s = sluggo('test', { def: '' });
     assert.strictEqual(s, 'test');
   });
+  it('allows an array of exceptions', function () {
+    var s = sluggo("/@/slug url", { allow: ['/', '@'] })
+    assert.strictEqual(s, '/@/slug-url')
+  })
 });


### PR DESCRIPTION
For     https://linear.app/apostrophecms/issue/PRO-4125/create-the-template-library-module-with-template-query-builder, accept an array for "allow" option in sluggo