### PR TITLE
release 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Feel free to [open issues on Github](http://github.com/apostrophecms/sluggo/issu
 
 ## Changelog
 
-### Unreleased
-- Accepts an array of exceptions in the `allow` options property while still accepting a string.
+### 1.0.0 - 2023-05-03
+- Accepts an array of exceptions in the `allow` options property while still accepting a string. Declared stable.
 
 ### 0.3.1 - 2021-04-23
 - Accepts the empty string as a legitimate value for `def`, as was always intended, rather than forcing `none` in that situation. If `def` is not set at all `none` is still the fallback default.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sluggo",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "description": "High-speed, unicode-aware, browser-friendly slug generator",
   "main": "sluggo.js",
   "scripts": {


### PR DESCRIPTION
Just a release. Bumped to 1.0.0 because this is a long-stable module and we need semver deps to behave more reasonably for it going forward. We will need to bump apostrophe to actually use it.